### PR TITLE
feat(security): add write-enable flag to control state-changing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ UYUNI_USER=admin
 UYUNI_PASS=admin
 # Optional: Set to 'false' to disable SSL certificate verification. Defaults to 'true'.
 # UYUNI_SSL_VERIFY=false
+# Optional: Set to 'true' to enable tools that perform write actions (e.g., POST requests). Defaults to 'false'.
+# UYUNI_MCP_WRITE_TOOLS_ENABLED=false
 # Optional: Set the transport protocol. Can be 'stdio' (default) or 'http'.
 # UYUNI_MCP_TRANSPORT=stdio
 
 > [!WARNING]
 > **Security Note on HTTP Transport:** When `UYUNI_MCP_TRANSPORT` is set to `http`, the server runs without authentication. This means any client with network access can execute commands. Only use this mode in a trusted, isolated network environment. For more details, see the Security Policy.
+
+> [!WARNING]
+> **Security Note on Write Tools:** Enabling `UYUNI_MCP_WRITE_TOOLS_ENABLED` allows the execution of state-changing and potentially destructive actions (e.g., removing systems, applying updates). When combined with `UYUNI_MCP_TRANSPORT=http`, this risk is amplified, as any client with network access can perform these actions. Only enable write tools in a trusted environment.
 
 # Optional: Set the path for the server log file. Defaults to logging to the console.
 # UYUNI_MCP_LOG_FILE_PATH=/var/log/mcp-server-uyuni.log

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,20 +20,29 @@ UYUNI_PASS=<your_uyuni_password>
 *   **Critical:** This `config` file **must not be shared or committed to version control**. It should be treated as highly confidential.
 *   **Usage:** The MCP server imports this file as an environment file to obtain the necessary credentials for interacting with the Uyuni server.
 
-## MCP Server Authentication
+## MCP Server Authentication and Authorization
 
 *   **No Authentication:** Currently, the MCP server itself does not implement any form of authentication or authorization.
 *   **Access Implication:** Anyone who has access to the environment where the MCP server can be run, can execute any of the tools and actions provided by the MCP server.
-*
+
+### Write Tool Enablement (Default: Disabled)
+
+By default, the server runs in a **read-only** mode for safety. All tools that can change the state of the Uyuni server or the systems it manages (e.g., `remove_system`, `schedule_apply_pending_updates_to_system`) are disabled and not visible to the language model.
+
+To enable these "write tools", you must explicitly set the `UYUNI_MCP_WRITE_TOOLS_ENABLED` environment variable to `true`.
+
+> [!WARNING]
+> Enabling write tools is a significant security decision. It grants any client that can connect to the MCP server the ability to perform destructive actions. This risk is amplified when using the `http` transport.
+
 ### Transport Layer Implications
 
 The server can be run with two different transport layers, configured via the `UYUNI_MCP_TRANSPORT` environment variable:
 
 *   **`stdio` (default):** In this mode, the server communicates over standard input/output. Access is limited to processes that can execute the server binary directly on the host machine. This is the most secure mode of operation.
-*   **`http`:** In this mode, the server runs as an HTTP service. Because there is no authentication layer, **any client with network access to the server's host and port can execute any tool**. This includes destructive actions like removing systems or applying updates.
+*   **`http`:** In this mode, the server runs as an HTTP service. Because there is no authentication layer, **any client with network access to the server's host and port can execute any tool**.
 
 > [!WARNING]
-> Running the server with the `http` transport in an untrusted network environment poses a significant security risk. It is recommended to use this mode only in isolated, trusted networks or to implement network-level controls (e.g., firewall rules) to restrict access to authorized clients only.
+> Running the server with `UYUNI_MCP_TRANSPORT=http` and `UYUNI_MCP_WRITE_TOOLS_ENABLED=true` in an untrusted network environment poses a significant security risk. This combination allows any client with network access to perform destructive actions without authentication. It is strongly recommended to use this configuration only in isolated, trusted networks or to implement network-level controls (e.g., firewall rules) to restrict access to authorized clients only.
 
 ## Tool Execution and Confirmation
 

--- a/TEST_CASES.md
+++ b/TEST_CASES.md
@@ -9,6 +9,8 @@ This document tracks the manual test cases executed for different versions/tags 
 
 This document tracks the manual test cases executed for different versions/tags of the `mcp-server-uyuni` project.
 
+To run any tests that perform write actions, the UYUNI_MCP_WRITE_TOOLS_ENABLED environment variable must be set to true.
+
 ## Test Case Table
 
 | Test Case ID | Tool / Feature Tested                      | Question / Prompt                                           | Expected Result                                                                                                                                                           | Status (v0.1.0) | Status (v0.2.0) | Status (v0.2.1) | Status (v0.3.0) | Status (v0.4.0) | Notes / Bug ID |


### PR DESCRIPTION
To enhance security and prevent accidental or unauthorized modifications, the server now operates in a read-only mode by default. All tools that perform write operations (via POST requests) are disabled unless explicitly enabled.

This is implemented through:
- A new environment variable, `UYUNI_MCP_WRITE_TOOLS_ENABLED`, which must be set to 'true' to activate write capabilities.
- A `@write_tool` decorator that conditionally registers tools based on this flag, making them invisible to the LLM when disabled.
- A secondary safety check in the `_call_uyuni_api` helper to block any direct POST requests if the flag is not enabled.
- Updated documentation (README.md, SECURITY.md, CONTRIBUTING.md, TEST_CASES.md) to reflect the new security model and testing requirements.

This provides a robust, layered approach to securing the server against unintended state changes.

Fixes https://github.com/SUSE/spacewalk/issues/27567