### PR TITLE
OAuth support with external idP

### DIFF
--- a/src/mcp_server_uyuni/auth.py
+++ b/src/mcp_server_uyuni/auth.py
@@ -4,7 +4,7 @@ from pydantic import AnyHttpUrl
 
 
 class AuthProvider(RemoteAuthProvider):
-    def __init__(self, auth_server, write_enabled=False):
+    def __init__(self, auth_server, base_url, write_enabled=False):
         required_scopes = ["mcp:read"]
         if write_enabled:
             required_scopes.append("mcp:write")
@@ -19,5 +19,5 @@ class AuthProvider(RemoteAuthProvider):
         super().__init__(
             token_verifier=verifier,
             authorization_servers=[AnyHttpUrl(auth_server)],
-            base_url="http://localhost:8000", #TODO: Get URL dynamically?
+            base_url=base_url,
         )

--- a/src/mcp_server_uyuni/server.py
+++ b/src/mcp_server_uyuni/server.py
@@ -50,10 +50,13 @@ UYUNI_MCP_SSL_VERIFY = os.environ.get('UYUNI_MCP_SSL_VERIFY', 'true').lower() no
 UYUNI_MCP_WRITE_TOOLS_ENABLED = os.environ.get('UYUNI_MCP_WRITE_TOOLS_ENABLED', 'false').lower() in ('true', '1', 'yes')
 UYUNI_MCP_TRANSPORT = os.environ.get('UYUNI_MCP_TRANSPORT', 'stdio')
 UYUNI_MCP_LOG_FILE_PATH = os.environ.get('UYUNI_MCP_LOG_FILE_PATH') # Defaults to None if not set
+UYUNI_MCP_HOST = os.environ.get('UYUNI_MCP_HOST', '127.0.0.1')
+UYUNI_MCP_PORT = int(os.environ.get('UYUNI_MCP_PORT', 8000))
+base_url = f"http://{UYUNI_MCP_HOST}:{UYUNI_MCP_PORT}"
 
 AUTH_SERVER = os.environ.get("UYUNI_AUTH_SERVER")
 
-auth_provider = AuthProvider(AUTH_SERVER, UYUNI_MCP_WRITE_TOOLS_ENABLED) if AUTH_SERVER else None
+auth_provider = AuthProvider(AUTH_SERVER, base_url, UYUNI_MCP_WRITE_TOOLS_ENABLED) if AUTH_SERVER else None
 mcp = FastMCP("mcp-server-uyuni", auth=auth_provider)
 
 logger = get_logger(log_file=UYUNI_MCP_LOG_FILE_PATH, transport=UYUNI_MCP_TRANSPORT)
@@ -1257,10 +1260,10 @@ def main_cli():
     logger.info("Running Uyuni MCP server.")
 
     if UYUNI_MCP_TRANSPORT == Transport.HTTP.value:
-        mcp.run(transport="streamable-http")
+        mcp.run(transport="streamable-http", host=UYUNI_MCP_HOST, port=UYUNI_MCP_PORT)
     elif UYUNI_MCP_TRANSPORT == Transport.STDIO.value:
         mcp.run(transport="stdio")
     else:
-        # Defaults to stdio transport anyway 
+        # Defaults to stdio transport anyway
         # But I explicitety state it here for clarity
         mcp.run(transport="stdio")


### PR DESCRIPTION
Allows using an external idP for OAuth 2 authentication with protected resource metadata.

Fixes: https://github.com/SUSE/spacewalk/issues/27633

## How to test with Keycloak (insecure!)

1. Start a Keycloak instance

```sh
docker run -d --name keycloak-http -p 8080:8080 \
    -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
    -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
    quay.io/keycloak/keycloak:latest start-dev
```

### Setting up the client

1. Login to the web console with the admin account
2. Create a new realm (e.g. `uyuni`)
3. Create a new client (e.g. `mcp-server-uyuni`)
4. In the "Capabilities" section of the new client, set up the following:
    - Client authentication: Off
    - Standard flow: Checked
5. Add "*" as "Web Origins" (To enable CORS from any URL)
6. Add your MCP client's expected callback URI to the "Valid redirect URIs"
    - Depends on the client. For example, if on the same host, gemini-cli's URL would be `http://localhost:7777/oauth/callback`
7. After creating the client, go to the "Client Scopes" tab and click on "mcp-server-uyuni-dedicated"
8. Under the "Scope" tab, turn "Full scope allowed" off
9. Under the "Mappers" tab, click on "Configure a new mapper" and select "Audience"
10. Pick a name (e.g. `audience-mapper`) and select `mcp-server-uyuni` in the Included Client Audience tab.
11. Leave the other fields as is and click `Save`.
12. Go to "Client scopes" on the left menu bar
13. Create two client scopes with the following values:
```
  - Name: `mcp:read`
  - Description: `Execute read-only tools`
  - Type: Default
  - Protocol: OpenID Connect
  - Display on consent screen: On 
  - Consent screen text: `Execute read-only tools`
  - Include in token scope: On

  - Name: `mcp:write`
  - Description: `Execute write-enabled tools`
  - Type: Optional
  - Protocol: OpenID Connect
  - Display on consent screen: On 
  - Consent screen text: `Execute read-only tools`
  - Include in token scope: On
```

14. Go back to `uyuni-mcp-server` client details, to "Client scopes" tab and add `mcp:read` (Default) and `mcp:write` (Optional) client scopes.


### Setting up a test user

1. Go to create user page and fill out `username` and `email`
2. Set "Email verified" to On
3. Remove any entries in the "Required user actions" input
4. Create the user
5. Go to "Credentials" tab and create a password for the user (make sure the "Temporary" is off)

### Test config for gemini-cli

*Gemini doesn't seem to be able to consume protected resource metadata files properly, so we need to add the auth endpoints manually.*

**`.gemini/settings.json`:**
```json
  "mcpServers": {
    "mcp-server-uyuni": {
      "httpUrl": "http://localhost:8000",
      "description": "Tools to interact with the Uyuni/Multi-Linux Manager/MLM server.",
      "oauth": {
        "enabled": true,
        "clientId": "mcp-server-uyuni",
        "authorizationUrl": "http://<keycloak_url>/realms/<your_realm>/protocol/openid-connect/auth",
        "tokenUrl": "http://<keycloak_url>/realms/<your_realm>/protocol/openid-connect/token"
      }
    }
```

### Testing with MCP inspector

1. Open MCP inspector web UI
    - Transport Type: Streamable HTTP
    - URL: `http://localhost:8000`
2. In "Authentication" dropdown, under "OAuth 2.0 Flow":
    - Client ID `mcp-server-uyuni` (or whatever is set in Keycloak)
    - Copy the "Redirect URL" and add it as a "Valid redirect URI" in Keycloak
    - Click "Connect"
    
### Testing with VS Code

Add the following to the `mcp.json` file:

```json
	"servers": {
		"mcp-server-uyuni": {
			"url": "http://localhost:8000",
			"type": "http"
		}
	},
```

Click "Connect" and follow the instructions for the OAuth flow. When instructed, add the VSCode callback URLs to the Keycloak client "Valid Callback URLs".