### PR TITLE
Forward OAuth tokens to Uyuni server

### DIFF
--- a/src/mcp_server_uyuni/config.py
+++ b/src/mcp_server_uyuni/config.py
@@ -1,9 +1,7 @@
 import os
 
 REQUIRED_VARS = [
-    "UYUNI_SERVER",
-    "UYUNI_USER",
-    "UYUNI_PASS",
+    "UYUNI_SERVER"
 ]
 
 missing_vars = [key for key in REQUIRED_VARS if key not in os.environ]


### PR DESCRIPTION
Extracts the JWT token from the requests, logs into Uyuni server using the token instead of user/pass. The token auth uses the new `/manager/api/oicdLogin` endpoint. The rest of the flow is done using the usual session key from Uyuni.

### Notes:

- `oicdLogin` endpoint will be introduced in MLM 5.1.2 (expected early 2026)
- The server falls back to the usual user/pass auth with env vars if `UYUNI_AUTH_SERVER` is not configured.
- user/pass auth is still used when the MCP server is run in STDIO mode.

Related PR in the Uyuni repo: https://github.com/uyuni-project/uyuni/pull/11084

Fixes https://github.com/SUSE/spacewalk/issues/28483