### PR TITLE
Fix nested tool calls

### DIFF
--- a/src/mcp_server_uyuni/server.py
+++ b/src/mcp_server_uyuni/server.py
@@ -419,6 +419,9 @@ async def check_system_updates(system_identifier: Union[str, int], ctx: Context)
     log_string = f"Checking pending updates for system {system_identifier}"
     logger.info(log_string)
     await ctx.info(log_string)
+    return await _check_system_updates(system_identifier, ctx)
+
+async def _check_system_updates(system_identifier: Union[str, int], ctx: Context) -> Dict[str, Any]:
     system_id = await _resolve_system_id(system_identifier)
     default_error_response = {
         'system_identifier': system_identifier,
@@ -456,7 +459,7 @@ async def check_system_updates(system_identifier: Union[str, int], ctx: Context)
             unscheduled_errata_call
         )
         relevant_updates_list, unscheduled_updates_list = results
-        
+
         if not isinstance(relevant_updates_list, list) or not isinstance(unscheduled_updates_list, list):
             logger.error(
                 f"API calls for system {system_id} did not return lists as expected. "
@@ -485,7 +488,7 @@ async def check_system_updates(system_identifier: Union[str, int], ctx: Context)
                 update_details['application_status'] = 'Pending'
             else:
                 update_details['application_status'] = 'Queued'
-            
+
             # Initialize and fetch CVEs
             update_details['cves'] = []
             if advisory_name:
@@ -557,7 +560,7 @@ async def check_all_systems_for_updates(ctx: Context) -> List[Dict[str, Any]]:
 
         print(f"Checking updates for system: {system_name} (ID: {system_id})")
         # Use the existing check_system_updates tool
-        update_check_result = await check_system_updates(system_id, ctx)
+        update_check_result = await _check_system_updates(system_id, ctx)
 
         if update_check_result.get('has_pending_updates', False):
             # If the system has updates, add its info and update details to the result list
@@ -599,7 +602,7 @@ async def schedule_apply_pending_updates_to_system(system_identifier: Union[str,
         return f"CONFIRMATION REQUIRED: This will apply pending updates to the system {system_identifier}.  Do you confirm?"
 
     # 1. Use check_system_updates to get relevant errata
-    update_info = await check_system_updates(system_identifier, ctx)
+    update_info = await _check_system_updates(system_identifier, ctx)
 
     if not update_info or not update_info.get('has_pending_updates'):
         print(f"No pending updates found for system {system_identifier}, or an error occurred while fetching update information.")


### PR DESCRIPTION
Whenever the server tries to make a nested tool call, it fails with the following error because of `@mcp.tool` wrapping:

> TypeError: 'FunctionTool' object is not callable 

This PR extracts the business logic to separate methods and uses these plain methods for nested calls to fix the problem.

How to reproduce:

Execute the tool: `schedule_apply_pending_updates_to_system`. It fails with the error when it tries to call the nested `check_system_updates` tool.