### PR TITLE
Minor fixes for server.py

### DIFF
--- a/src/mcp_server_uyuni/server.py
+++ b/src/mcp_server_uyuni/server.py
@@ -1506,6 +1506,7 @@ async def list_activation_keys(ctx: Context) -> List[Dict[str, str]]:
                 await ctx.warning(msg)
     return filtered_keys
 
+@mcp.tool()
 async def get_unscheduled_errata(system_id: int, ctx: Context) -> List[Dict[str, Any]]:
     """
     Provides a list of errata that are applicable to the system with the system_id


### PR DESCRIPTION
These are just a couple of minor fixes throughout `server.py`:

- SSL verification consistency: consider `UYUNI_MCP_SSL_VERIFY` everywhere rather than hardcoding it to `false`
- `get_unscheduled_errata()`: add tool registration (`@mcp.tool()`) and fix return type
- Several typo fixes in docstrings and comments

@ycedres those might be obsolete after we merged your currently open PRs (just saw them, especially #30 and #31), feel free to ignore and close this PR in this case.