### PR TITLE
Graceful exit in case of non-existent system

### DIFF
--- a/src/mcp_server_uyuni/uyuni_api.py
+++ b/src/mcp_server_uyuni/uyuni_api.py
@@ -102,8 +102,9 @@ async def call(
                 # Prefer the expected_result_key but return full response dict as a fallback
                 return response_data.get(expected_result_key, response_data)
             else:
-                logger.error(f"Uyuni API reported failure for {error_context}. Response: {response_data}")
-                raise UnexpectedResponse(full_api_url, response_data.get('message', response_data))
+                message = response_data.get('message', str(response_data))
+                logger.warning(f"Uyuni API reported failure for {error_context}. Response: {response_data}")
+                raise UnexpectedResponse(full_api_url, message)
 
         # Otherwise return whatever we received (list, dict, string, etc.)
         return response_data

--- a/test/acceptance_tests.py
+++ b/test/acceptance_tests.py
@@ -227,6 +227,12 @@ def main():
         default=None,
         help="Model to use for judging the test results. Defaults to the test model if not specified.",
     )
+    parser.add_argument(
+        "--test-id",
+        type=str,
+        default=None,
+        help="Run a specific test case by its ID.",
+    )
     args = parser.parse_args()
 
     if not args.test_cases_file.is_file():
@@ -261,6 +267,14 @@ def main():
 
     with open(args.test_cases_file, "r", encoding="utf-8") as f:
         test_cases = json.load(f)
+
+    if args.test_id:
+        original_count = len(test_cases)
+        test_cases = [tc for tc in test_cases if tc.get("id") == args.test_id]
+        if not test_cases:
+            print(f"Error: Test case with ID '{args.test_id}' not found.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Filtered tests: Running 1 test out of {original_count}.")
 
     results = []
     passed_count = 0

--- a/test/test_config.json
+++ b/test/test_config.json
@@ -3,30 +3,30 @@
     "proxy": {
       "id": "1000010000",
       "name": "suma-test-ai-proxy.mgr.suse.de",
-      "cpu_model": "AMD EPYC-Milan Processor"
+      "cpu_model": "AMD EPYC-Genoa Processor"
     },
     "build_host": {
-      "id": "1000010005",
+      "id": "1000010003",
       "name": "suma-test-ai-build-host.mgr.suse.de",
       "cpu_model": "QEMU Virtual CPU"
     },
     "deblike_minion": {
-      "id": "1000010004",
+      "id": "1000010002",
       "name": "suma-test-ai-deblike-minion.mgr.suse.de",
       "cpu_model": "QEMU Virtual CPU"
     },
     "rhlike_minion": {
-      "id": "1000010003",
+      "id": "1000010001",
       "name": "suma-test-ai-rhlike-minion.mgr.suse.de",
       "cpu_model": "QEMU Virtual CPU"
     },
     "suse_minion": {
-      "id": "1000010001",
+      "id": "1000010004",
       "name": "suma-test-ai-suse-minion.mgr.suse.de",
       "cpu_model": "QEMU Virtual CPU"
     },
     "suse_ssh_minion": {
-      "id": "1000010002",
+      "id": "1000010005",
       "name": "suma-test-ai-suse-sshminion.mgr.suse.de",
       "cpu_model": "QEMU Virtual CPU"
     },


### PR DESCRIPTION
This PR modifies `get_system_details` to gracefully handle the case where a system does not exist. 

Also fixes concurrent request failures by updating asyncio.gather usage in `_get_system_details` to include `return_exceptions=True`. This prevents a "stack trace storm" of `httpx.ReadErrors` that occurred when one task failed (e.g., due to a missing system) and cancelled other in-flight requests sharing the same `httpx.AsyncClient`.

Besides, adds a `--test-id` argument to `acceptance_tests.py` to allow running individual test cases.
