### PR TITLE
Change default model and update model handling

### DIFF
--- a/test/acceptance_tests.py
+++ b/test/acceptance_tests.py
@@ -83,7 +83,7 @@ def _run_command(runner, prompt, config_path, model, debug=False):
             "--prompt",
             prompt,
             "--model",
-            model,
+            model.removeprefix("google:"),
         ]
     else:
         return f"Error: Unsupported runner '{runner}'"
@@ -241,8 +241,8 @@ def main():
         "-m",
         "--model",
         type=str,
-        default="google:gemini-2.5-flash",
-        help="Model to use for the tests (e.g., 'google:gemini-2.5-flash').",
+        default="google:gemini-2.5-flash-lite",
+        help="Model to use for the tests (e.g., 'google:gemini-2.5-flash-lite').",
     )
     parser.add_argument(
         "--runner",


### PR DESCRIPTION
Updated model argument to use 'google:gemini-2.5-flash-lite' instead of 'google:gemini-2.5-flash'. Modified model handling to remove 'google:' prefix.