### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Unit Tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
Potential fix for [https://github.com/uyuni-project/mcp-server-uyuni/security/code-scanning/2](https://github.com/uyuni-project/mcp-server-uyuni/security/code-scanning/2)

In general, to fix this issue you should explicitly define a `permissions:` block for the workflow or for the specific job, granting only the minimal scopes needed. For a unit test workflow that only checks out code and runs tests, `contents: read` is typically sufficient, since the job does not need to push commits, create releases, or modify issues/PRs.

The best fix here, without changing existing functionality, is to add a `permissions:` block at the top level of the workflow (so it applies to all jobs) with `contents: read`. Concretely, in `.github/workflows/unit_tests.yml`, insert:

```yaml
permissions:
  contents: read
```

right after the `on:` block (or before `jobs:`). This will restrict the `GITHUB_TOKEN` used in this workflow to read-only repository contents, which is enough for `actions/checkout` and the test commands, and it matches the minimal starting point suggested by CodeQL.

No additional imports, methods, or external definitions are needed; this is purely a YAML configuration change within the existing workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
