### PR TITLE
Add security scanning workflows (Bandit + Grype)

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,38 @@
+name: Bandit Security Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  bandit:
+    name: Bandit Python SAST
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
+      - name: Run Bandit
+        run: uv run --with 'bandit[sarif]' bandit -r src/ -f screen
+
+      - name: Generate SARIF report
+        if: always() && github.event_name != 'pull_request'
+        run: uv run --with 'bandit[sarif]' bandit -r src/ -f sarif -o bandit-results.sarif || true
+
+      - name: Upload Bandit results to GitHub Security tab
+        if: always() && github.event_name != 'pull_request'
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        with:
+          sarif_file: "bandit-results.sarif"

--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -1,0 +1,63 @@
+name: Grype Security Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  dependency-scan:
+    name: Scan Dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Grype dependency scanner
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        id: scan
+        with:
+          path: "."
+          fail-build: true
+          severity-cutoff: high
+
+      - name: Upload Grype dependency results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        if: always()
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: grype-dependency-scan
+
+  container-scan:
+    name: Scan Container Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build image for scanning
+        run: docker build -t mcp-server-uyuni:scan .
+
+      - name: Run Grype container scanner
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        id: scan
+        with:
+          image: "mcp-server-uyuni:scan"
+          fail-build: true
+          severity-cutoff: high
+
+      - name: Upload Grype container results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+        if: always()
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: grype-container-scan

--- a/src/mcp_server_uyuni/server.py
+++ b/src/mcp_server_uyuni/server.py
@@ -43,7 +43,7 @@ def _get_public_base_url(config: Dict[str, Any]) -> str:
         return public_url.rstrip("/")
 
     public_host = config["UYUNI_MCP_HOST"]
-    if public_host in {"0.0.0.0", "::", "[::]"}:
+    if public_host in {"0.0.0.0", "::", "[::]"}:  # nosec B104
         public_host = "127.0.0.1"
 
     return f'http://{public_host}:{config["UYUNI_MCP_PORT"]}'
@@ -1161,7 +1161,7 @@ async def _add_system(
 
     ssh_priv_key_pass = os.environ.get('UYUNI_SSH_PRIV_KEY_PASS')
     if not ssh_priv_key_pass:
-        ssh_priv_key_pass = ""
+        ssh_priv_key_pass = ""  # nosec B105
 
     payload = {
         "host": host,


### PR DESCRIPTION
Add Bandit for Python SAST and Grype for both dependency and container image scanning. Both run on push, PRs, and weekly schedule, with SARIF results uploaded to the GitHub Security tab. All actions pinned to commit SHAs.

Closes #88