### PR TITLE
Auth configuration hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Create a file (e.g., `uyuni-config.env`) to store your environment variables. Yo
 # Required fields
 #
 # Basic API parameters
-UYUNI_SERVER=192.168.1.124:8443
+UYUNI_SERVER=https://192.168.1.124:8443
 
 # Optional fields
 #
@@ -94,7 +94,7 @@ UYUNI_MCP_PORT=8080
 UYUNI_MCP_PUBLIC_URL=http://127.0.0.1:8080
 
 # OAuth 2.0 authorization server
-UYUNI_AUTH_SERVER=auth.example.com
+UYUNI_AUTH_SERVER=https://auth.example.com
 
 # Set the path for the server log file. Defaults to logging to the console.
 UYUNI_MCP_LOG_FILE_PATH=/var/log/mcp-server-uyuni.log
@@ -175,7 +175,7 @@ Pre-built container images are available on the GitHub Container Registry. Refer
           "command": "docker",
           "args": [
             "run", "-i", "--rm",
-            "-e", "UYUNI_SERVER=192.168.1.124:8443",
+            "-e", "UYUNI_SERVER=https://192.168.1.124:8443",
             "-e", "UYUNI_USER=admin",
             "-e", "UYUNI_PASS=admin",
             "ghcr.io/uyuni-project/mcp-server-uyuni:VERSION"
@@ -196,7 +196,7 @@ UYUNI_MCP_TRANSPORT=http
 UYUNI_MCP_HOST=0.0.0.0 # Or a specific interface
 UYUNI_MCP_PORT=8080
 UYUNI_MCP_PUBLIC_URL=https://mcp.example.com # Client-facing MCP base URL used for OAuth discovery
-UYUNI_AUTH_SERVER=auth.example.com
+UYUNI_AUTH_SERVER=https://auth.example.com
 ```
 
 `UYUNI_MCP_HOST` controls where the server binds. `UYUNI_MCP_PUBLIC_URL` controls the URL advertised to OAuth-capable clients. Do not set the public URL to `0.0.0.0`.

--- a/src/mcp_server_uyuni/config.py
+++ b/src/mcp_server_uyuni/config.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from urllib.parse import urlparse, urlunparse
 
 REQUIRED_VARS = [
     "UYUNI_SERVER"
@@ -11,22 +12,77 @@ if missing_vars:
         f"Failed to import config: Missing required environment variables: {', '.join(missing_vars)}"
     )
 
-UYUNI_SERVER = 'https://' + os.environ["UYUNI_SERVER"]
+
+def _normalize_uri(raw_value: str, var_name: str, allow_path: bool, default_scheme: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        raise ImportError(f"Failed to import config: {var_name} must not be empty")
+
+    if "://" not in value:
+        value = f"{default_scheme}://{value}"
+
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ImportError(
+            f"Failed to import config: {var_name} must use http or https and include a host"
+        )
+
+    if parsed.params or parsed.query or parsed.fragment:
+        raise ImportError(
+            f"Failed to import config: {var_name} must not include params, query, or fragment"
+        )
+
+    if not allow_path and parsed.path not in ("", "/"):
+        raise ImportError(
+            f"Failed to import config: {var_name} must not include a path"
+        )
+
+    normalized_path = parsed.path.rstrip("/") if allow_path else ""
+    normalized = parsed._replace(path=normalized_path, params="", query="", fragment="")
+    return urlunparse(normalized)
+
+
+UYUNI_SERVER = _normalize_uri(
+    os.environ["UYUNI_SERVER"],
+    "UYUNI_SERVER",
+    allow_path=False,
+    default_scheme="https",
+)
 UYUNI_USER = os.environ.get("UYUNI_USER")
 UYUNI_PASS = os.environ.get("UYUNI_PASS")
 
 UYUNI_MCP_HOST = os.environ.get("UYUNI_MCP_HOST", "127.0.0.1")
 UYUNI_MCP_PORT = int(os.environ.get("UYUNI_MCP_PORT", "8000"))
 UYUNI_MCP_PUBLIC_URL = os.environ.get("UYUNI_MCP_PUBLIC_URL")
-UYUNI_AUTH_SERVER = os.environ.get("UYUNI_AUTH_SERVER", None)
+
+UYUNI_AUTH_SERVER = os.environ.get("UYUNI_AUTH_SERVER")
+UYUNI_AUTH_SERVER = (
+    _normalize_uri(
+        UYUNI_AUTH_SERVER,
+        "UYUNI_AUTH_SERVER",
+        allow_path=True,
+        default_scheme="https",
+    )
+    if UYUNI_AUTH_SERVER and UYUNI_AUTH_SERVER.strip()
+    else None
+)
 
 UYUNI_MCP_SSL_VERIFY = (
     os.environ.get("UYUNI_MCP_SSL_VERIFY", "true").lower()
     not in ("false", "0", "no")
 )
-UYUNI_MCP_WRITE_TOOLS_ENABLED = os.environ.get('UYUNI_MCP_WRITE_TOOLS_ENABLED', 'false').lower() in ('true', '1', 'yes')
+
+UYUNI_MCP_WRITE_TOOLS_ENABLED = (
+    os.environ.get('UYUNI_MCP_WRITE_TOOLS_ENABLED', 'false').lower()
+    in ('true', '1', 'yes')
+)
+
 UYUNI_MCP_TIMEOUT = float(os.environ.get('UYUNI_MCP_TIMEOUT', '30'))
-UYUNI_MCP_TRANSPORT = os.environ.get('UYUNI_MCP_TRANSPORT', 'stdio')
+UYUNI_MCP_TRANSPORT = os.environ.get('UYUNI_MCP_TRANSPORT', 'stdio').strip().lower()
+if UYUNI_MCP_TRANSPORT not in ('stdio', 'http'):
+    raise ImportError(
+        "Failed to import config: UYUNI_MCP_TRANSPORT must be either 'stdio' or 'http'"
+    )
 UYUNI_MCP_LOG_FILE_PATH = os.environ.get('UYUNI_MCP_LOG_FILE_PATH')
 
 log_level_str = os.environ.get('UYUNI_MCP_LOG_LEVEL', 'info').upper()

--- a/src/mcp_server_uyuni/errors.py
+++ b/src/mcp_server_uyuni/errors.py
@@ -18,7 +18,7 @@ class HTTPError(APIError):
     """
 
     def __init__(self, status_code: int, url: str, body: str | None = None):
-        msg = f"HTTP error {status_code} for {url}. Response body: {body!r}"
+        msg = f"Uyuni API request failed with HTTP {status_code} at {url}. Response body: {body!r}"
         super().__init__(msg)
         self.status_code = status_code
         self.url = url
@@ -42,11 +42,11 @@ class NetworkError(APIError):
     def __init__(self, url: str, original: Exception | None = None, timed_out: bool = False):
         if timed_out:
             msg = (
-                f"Timeout while contacting Uyuni at {url}. This may indicate a long-running "
-                "action or network issues. Original: {original}"
+                f"Uyuni API request timed out at {url}. This may indicate a long-running "
+                f"action or network issues. Original: {original}"
             )
         else:
-            msg = f"Network error while contacting Uyuni at {url}: {original}"
+            msg = f"Uyuni API request failed due to a network error at {url}. Original: {original}"
         super().__init__(msg)
         self.url = url
         self.original = original
@@ -63,7 +63,7 @@ class UnexpectedResponse(APIError):
     """
 
     def __init__(self, url: str, response: str | None = None):
-        msg = f"Unexpected response from Uyuni at {url}: {response!r}"
+        msg = f"Uyuni API returned an unexpected response at {url}: {response!r}"
         super().__init__(msg)
         self.url = url
         self.response = response

--- a/src/mcp_server_uyuni/server.py
+++ b/src/mcp_server_uyuni/server.py
@@ -56,8 +56,16 @@ def _get_public_base_url(config: Dict[str, Any]) -> str:
     return f'http://{public_host}:{config["UYUNI_MCP_PORT"]}'
 
 
+def _get_action_url(action_id: int) -> str:
+    return f"{CONFIG['UYUNI_SERVER']}/rhn/schedule/ActionDetails.do?aid={action_id}"
+
+
 base_url = _get_public_base_url(CONFIG)
-auth_provider = AuthProvider(CONFIG["AUTH_SERVER"], base_url, CONFIG["UYUNI_MCP_WRITE_TOOLS_ENABLED"]) if CONFIG["AUTH_SERVER"] else None
+auth_provider = AuthProvider(
+    auth_server=CONFIG["AUTH_SERVER"],
+    base_url=base_url,
+    write_enabled=CONFIG["UYUNI_MCP_WRITE_TOOLS_ENABLED"],
+) if CONFIG["AUTH_SERVER"] else None
 product = CONFIG["UYUNI_PRODUCT_NAME"] if CONFIG["UYUNI_PRODUCT_NAME"] else "Uyuni" 
 mcp = FastMCP(
     "mcp-server-uyuni",
@@ -70,6 +78,12 @@ logger = get_logger(
     transport=CONFIG["UYUNI_MCP_TRANSPORT"],
     log_level=CONFIG["UYUNI_MCP_LOG_LEVEL"]
 )
+
+if CONFIG["AUTH_SERVER"]:
+    logger.info(f"OAuth issuer configured: {CONFIG['AUTH_SERVER']}")
+else:
+    if CONFIG["UYUNI_MCP_TRANSPORT"] == Transport.HTTP.value:
+        logger.warning("HTTP transport is running without UYUNI_AUTH_SERVER; requests are unauthenticated.")
 
 def _make_client() -> httpx.AsyncClient:
     """Create an AsyncClient with the configured SSL and timeout settings."""
@@ -1074,7 +1088,7 @@ async def _schedule_pending_updates_to_system(system_identifier: str, token: str
         if isinstance(api_result, list) and api_result and isinstance(api_result[0], int):
             action_id = api_result[0]
             logger.info(f"Successfully scheduled action {action_id} to apply {len(errata_ids)} errata to system {system_identifier}.")
-            return "Update successfully scheduled at " + CONFIG["UYUNI_SERVER"] + "/rhn/schedule/ActionDetails.do?aid=" + str(action_id)
+            return f"Update successfully scheduled. Action URL: {_get_action_url(action_id)}"
         else:
             msg = f"Failed to schedule errata for system {system_identifier}. Unexpected API response format. Result: {api_result}"
             logger.error(msg)
@@ -1128,13 +1142,13 @@ async def _schedule_specific_update(system_identifier: str, errata_id: Union[str
 
         if isinstance(api_result, list) and api_result and isinstance(api_result[0], int):
             action_id = api_result[0]
-            success_message = f"Update (errata ID: {errata_id_int}) successfully scheduled for system {system_identifier}. Action URL: {CONFIG['UYUNI_SERVER']}/rhn/schedule/ActionDetails.do?aid={action_id}"
+            success_message = f"Update (errata ID: {errata_id_int}) successfully scheduled for system {system_identifier}. Action URL: {_get_action_url(action_id)}"
             logger.info(success_message)
             return success_message
         # Some schedule APIs might return int directly in result (though scheduleApplyErrata usually returns a list)
         elif isinstance(api_result, int): # Defensive check
             action_id = api_result
-            success_message = f"Update (errata ID: {errata_id_int}) successfully scheduled. Action URL: {CONFIG['UYUNI_SERVER']}/rhn/schedule/ActionDetails.do?aid={action_id}"
+            success_message = f"Update (errata ID: {errata_id_int}) successfully scheduled. Action URL: {_get_action_url(action_id)}"
             logger.info(success_message)
             return success_message
         else:
@@ -1540,7 +1554,7 @@ async def _schedule_system_reboot(system_identifier: str, token: str, ctx: Conte
         # uyuni's scheduleReboot API returns an integer action ID directly in 'result'
         if isinstance(api_result, int):
             action_id = api_result
-            action_detail_url = f"{CONFIG['UYUNI_SERVER']}/rhn/schedule/ActionDetails.do?aid={action_id}"
+            action_detail_url = _get_action_url(action_id)
             success_message = f"System reboot successfully scheduled. Action URL: {action_detail_url}"
             logger.info(success_message)
             return success_message

--- a/src/mcp_server_uyuni/uyuni_api.py
+++ b/src/mcp_server_uyuni/uyuni_api.py
@@ -1,5 +1,4 @@
-import inspect
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 import httpx
 
 from .logging_config import get_logger
@@ -22,43 +21,69 @@ class UyuniApi:
         self.verify = verify
         self.timeout = timeout or httpx.Timeout(30.0, connect=10.0)
 
+
+async def _authenticate_client(
+    client: httpx.AsyncClient,
+    token: Optional[str] = None,
+    error_context: Optional[str] = None,
+) -> None:
+    """Authenticate an AsyncClient using token (OIDC) or username/password."""
+    login_url = CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/login'
+
+    try:
+        if token:
+            login_url = CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/oidcLogin'
+            response = await client.post(
+                login_url,
+                headers={"Authorization": f"Bearer {token}"}
+            )
+        elif CONFIG["UYUNI_USER"] and CONFIG["UYUNI_PASS"]:
+            response = await client.post(
+                login_url,
+                json={"login": CONFIG["UYUNI_USER"], "password": CONFIG["UYUNI_PASS"]}
+            )
+        else:
+            logger.warning(
+                "Skipping authentication%s: no token and no username/password configured.",
+                f" for {error_context}" if error_context else "",
+            )
+            return
+
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        status = e.response.status_code if e.response is not None else None
+        body = e.response.text if e.response is not None else ''
+        request_url = getattr(e.request, 'url', login_url)
+
+        if error_context is None:
+            logger.error(f"HTTP error during login: {request_url} - {status} - {body}")
+        else:
+            logger.error(f"HTTP error during login for {error_context}: {request_url} - {status} - {body}")
+
+        if status in (401, 403):
+            raise AuthError(status, login_url, body)
+        raise HTTPError(status or -1, login_url, body)
+    except httpx.RequestError as e:
+        request_url = getattr(e.request, 'url', login_url)
+
+        if error_context is None:
+            logger.exception(f"Request error during login: {request_url} - {e}")
+        else:
+            logger.exception(f"Request error during login for {error_context}: {request_url} - {e}")
+
+        raise NetworkError(login_url, e)
+
 async def login(client: httpx.AsyncClient, token: Optional[str] = None) -> None:
     """
     Authenticate the given AsyncClient against Uyuni.
     After this call the client holds a session cookie that can be reused
     for subsequent requests without re-logging in.
     """
-    try:
-        if token:
-            response = await client.post(
-                CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/oidcLogin',
-                headers={"Authorization": f"Bearer {token}"}
-            )
-        elif CONFIG["UYUNI_USER"] and CONFIG["UYUNI_PASS"]:
-            response = await client.post(
-                CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/login',
-                json={"login": CONFIG["UYUNI_USER"], "password": CONFIG["UYUNI_PASS"]}
-            )
-        else:
-            logger.warning("login() called but no token or username/password available; skipping.")
-            return
-        response.raise_for_status()
-    except httpx.HTTPStatusError as e:
-        status = e.response.status_code if e.response is not None else None
-        body = e.response.text if e.response is not None else ''
-        logger.error(f"HTTP error during login: {getattr(e.request, 'url', '')} - {status} - {body}")
-        from .errors import AuthError, HTTPError
-        if status in (401, 403):
-            raise AuthError(status, str(getattr(e.request, 'url', '')), body)
-        raise HTTPError(status or -1, str(getattr(e.request, 'url', '')), body)
-    except httpx.RequestError as e:
-        logger.exception(f"Request error during login: {getattr(e.request, 'url', '')} - {e}")
-        from .errors import NetworkError
-        raise NetworkError(getattr(e.request, 'url', ''), e)
+    await _authenticate_client(client, token=token)
 
 async def call(
     client: httpx.AsyncClient,
-    method: str,
+    method: Literal["GET", "POST"],
     api_path: str,
     error_context: str,
     token: Optional[str] = None,
@@ -73,9 +98,14 @@ async def call(
     Handles login, request execution, error handling, and basic response parsing.
     """
 
+    if method not in ("GET", "POST"):
+        raise APIError(
+            f"Unsupported HTTP method '{method}'. Expected 'GET' or 'POST'."
+        )
+
     # Safety check: Do not allow POST requests if write tools are disabled.
     # This acts as a secondary guard after the @write_tool decorator.
-    if method.upper() == 'POST' and not CONFIG["UYUNI_MCP_WRITE_TOOLS_ENABLED"]:
+    if method == 'POST' and not CONFIG["UYUNI_MCP_WRITE_TOOLS_ENABLED"]:
         error_msg = (
             f"Attempted to call a write API ({api_path}) while write tools are disabled. "
             "Please set UYUNI_MCP_WRITE_TOOLS_ENABLED to 'true' to enable them."
@@ -85,47 +115,24 @@ async def call(
 
     full_api_url = CONFIG["UYUNI_SERVER"] + api_path
     if perform_login:
-        try:
-            if token:
-                # Try OIDC login with provided token
-                login_response = await client.post(
-                    CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/oidcLogin',
-                    headers={"Authorization": f"Bearer {token}"}
-                )
-                login_response.raise_for_status()
-            elif CONFIG["UYUNI_USER"] and CONFIG["UYUNI_PASS"]:
-                login_response = await client.post(
-                    CONFIG["UYUNI_SERVER"] + '/rhn/manager/api/login',
-                    json={"login": CONFIG["UYUNI_USER"], "password": CONFIG["UYUNI_PASS"]}
-                )
-                login_response.raise_for_status()
-            else:
-                logger.warning(f"perform_login=True but no token or username/password available for {error_context}; skipping login.")
-        except httpx.HTTPStatusError as e:
-            status = e.response.status_code if e.response is not None else None
-            body = e.response.text if e.response is not None else ''
-            logger.error(f"HTTP error during login for {error_context}: {getattr(e.request,'url',full_api_url)} - {status} - {body}")
-            if status in (401, 403):
-                raise AuthError(status, str(getattr(e.request, 'url', full_api_url)), body)
-            raise HTTPError(status or -1, str(getattr(e.request, 'url', full_api_url)), body)
-        except httpx.RequestError as e:
-            logger.exception(f"Request error during login for {error_context}: {getattr(e.request,'url',full_api_url)} - {e}")
-            raise NetworkError(getattr(e.request, 'url', full_api_url), e)
+        await _authenticate_client(
+            client,
+            token=token,
+            error_context=error_context,
+        )
 
     try:
-        method_upper = method.upper()
-        if method_upper == 'GET':
-            logger.info(f"GETting from {full_api_url}")
-            response = await client.get(full_api_url, params=params)
-            logger.debug(f"GET response status: {response.status_code}")
-            logger.debug(f"GET response text: {response.text}")
-        elif method_upper == 'POST':
-            logger.info(f"POSTing to {full_api_url}")
-            response = await client.post(full_api_url, json=json_body, params=params)
-            logger.debug(f"POST response status: {response.status_code}")
-            logger.debug(f"POST response text: {response.text}")
-        else:
-            raise APIError(f"Unsupported HTTP method '{method}' for {error_context}.")
+        logger.info(f"{method} request to {full_api_url}")
+
+        response = await client.request(
+            method=method,
+            url=full_api_url,
+            params=params,
+            json=json_body,
+        )
+
+        logger.debug(f"{method} response status: {response.status_code}")
+        logger.debug(f"{method} response text: {response.text}")
 
         response.raise_for_status()
 
@@ -150,23 +157,40 @@ async def call(
     except httpx.HTTPStatusError as e:
         status = e.response.status_code if e.response is not None else None
         body = e.response.text if e.response is not None else ''
-        logger.error(f"HTTP error occurred while {error_context}: {getattr(e.request,'url',full_api_url)} - {status} - {body}")
+        request_url = getattr(e.request, "url", full_api_url)
+        logger.error(
+            f"HTTP error occurred while {error_context}: "
+            f"{request_url} - {status} - {body}"
+        )
         if status in (401, 403):
-            raise AuthError(status, str(getattr(e.request, 'url', full_api_url)), body)
-        raise HTTPError(status or -1, str(getattr(e.request, 'url', full_api_url)), body)
+            raise AuthError(status, full_api_url, body)
+        raise HTTPError(status or -1, full_api_url, body)
+
     except httpx.TimeoutException as e:
         logger.debug(f"Timeout! timeout expected? {expect_timeout}")
+        request_url = getattr(e.request, "url", full_api_url)
         if expect_timeout:
-            logger.info(f"A timeout occurred while {error_context} (expected for a long-running action): {getattr(e.request,'url',full_api_url)} - {e}")
+            logger.info(
+                f"A timeout occurred while {error_context} "
+                f"(expected for a long-running action): {request_url} - {e}"
+            )
             return TIMEOUT_HAPPENED
-        logger.warning(f"A timeout occurred while {error_context}: {getattr(e.request,'url',full_api_url)} - {e}")
-        raise NetworkError(getattr(e.request, 'url', full_api_url), e, timed_out=True)
+        logger.warning(
+            f"A timeout occurred while {error_context}: {request_url} - {e}"
+        )
+        raise NetworkError(full_api_url, e, timed_out=True)
+
     except httpx.RequestError as e:
-        logger.exception(f"Request error occurred while {error_context}: {getattr(e.request,'url',full_api_url)} - {e}")
-        raise NetworkError(getattr(e.request, 'url', full_api_url), e)
+        request_url = getattr(e.request, "url", full_api_url)
+        logger.exception(
+            f"Request error occurred while {error_context}: {request_url} - {e}"
+        )
+        raise NetworkError(full_api_url, e)
+
     except UnexpectedResponse:
         # Propagate API-specific failures unchanged
         raise
-    except Exception as e: # Catch other potential errors like JSONDecodeError
+
+    except Exception as e:  # Catch other potential errors like JSONDecodeError
         logger.exception(f"An unexpected error occurred while {error_context}: {e}")
         raise APIError(f"Unexpected error while {error_context}: {e}")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,66 @@
+import importlib
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+
+def _reload_config_module():
+    sys.modules.pop("mcp_server_uyuni.config", None)
+    return importlib.import_module("mcp_server_uyuni.config")
+
+
+def test_config_accepts_schemeless_uyuni_server(monkeypatch):
+    monkeypatch.setenv("UYUNI_SERVER", "mock-server.local")
+
+    config_module = _reload_config_module()
+
+    assert config_module.CONFIG["UYUNI_SERVER"] == "https://mock-server.local"
+
+
+def test_config_accepts_and_normalizes_uris(monkeypatch):
+    monkeypatch.setenv("UYUNI_SERVER", "https://mock-server.local/")
+    monkeypatch.setenv("UYUNI_AUTH_SERVER", "auth.example.com/realms/uyuni-mcp/")
+
+    config_module = _reload_config_module()
+
+    assert config_module.CONFIG["UYUNI_SERVER"] == "https://mock-server.local"
+    assert config_module.CONFIG["AUTH_SERVER"] == "https://auth.example.com/realms/uyuni-mcp"
+
+
+def test_config_rejects_non_http_scheme(monkeypatch):
+    monkeypatch.setenv("UYUNI_SERVER", "ftp://mock-server.local")
+
+    with pytest.raises(ImportError, match="UYUNI_SERVER must use http or https"):
+        _reload_config_module()
+
+
+def test_config_keeps_auth_optional(monkeypatch):
+    monkeypatch.setenv("UYUNI_SERVER", "https://mock-server.local")
+    monkeypatch.delenv("UYUNI_AUTH_SERVER", raising=False)
+
+    config_module = _reload_config_module()
+
+    assert config_module.CONFIG["AUTH_SERVER"] is None
+
+
+def test_auth_provider_uses_issuer_and_static_audience():
+    from mcp_server_uyuni.auth import AuthProvider
+
+    with patch("mcp_server_uyuni.auth.JWTVerifier") as verifier_mock, patch(
+        "mcp_server_uyuni.auth.RemoteAuthProvider.__init__", return_value=None
+    ):
+        AuthProvider(
+            auth_server="https://auth.example.com/realms/demo",
+            base_url="http://mcp.example",
+            write_enabled=True,
+        )
+
+    verifier_kwargs = verifier_mock.call_args.kwargs
+    assert verifier_kwargs["issuer"] == "https://auth.example.com/realms/demo"
+    assert verifier_kwargs["jwks_uri"] == "https://auth.example.com/realms/demo/protocol/openid-connect/certs"
+    assert verifier_kwargs["audience"] == "mcp-server-uyuni"
+    assert verifier_kwargs["required_scopes"] == ["mcp:read", "mcp:write"]

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
-os.environ.setdefault("UYUNI_SERVER", "mock-server.local")
+os.environ.setdefault("UYUNI_SERVER", "https://mock-server.local")
 os.environ.setdefault("UYUNI_USER", "mock-user")
 os.environ.setdefault("UYUNI_PASS", "mock-pass")
 os.environ.setdefault("UYUNI_MCP_WRITE_TOOLS_ENABLED", "true")
@@ -349,6 +349,7 @@ async def test_schedule_specific_update(mock_uyuni, mock_ctx):
 
     result = await server._schedule_specific_update(system_id, errata_id, mock_ctx, "mock_token")
     assert "successfully scheduled" in result
+    assert f"{base_url}/rhn/schedule/ActionDetails.do?aid=12345" in result
     assert route.called
 
     payload = json.loads(route.calls.last.request.content)
@@ -377,6 +378,7 @@ async def test_schedule_pending_updates_to_system(mock_uyuni, mock_ctx):
 
     result = await server._schedule_pending_updates_to_system(system_id, "mock_token", mock_ctx)
     assert "successfully scheduled" in result
+    assert f"{base_url}/rhn/schedule/ActionDetails.do?aid=12345" in result
     assert route_schedule.called
 
     payload = json.loads(route_schedule.calls.last.request.content)
@@ -412,6 +414,7 @@ async def test_schedule_system_reboot(mock_uyuni, mock_ctx):
 
     result = await server._schedule_system_reboot(system_id, "mock_token", mock_ctx)
     assert "successfully scheduled" in result
+    assert f"{base_url}/rhn/schedule/ActionDetails.do?aid=12346" in result
     assert route_reboot.called
 
 @pytest.mark.asyncio
@@ -854,6 +857,7 @@ async def test_api_error_500(mock_uyuni):
     with pytest.raises(HTTPError) as excinfo:
         await server._list_systems("mock_token")
     assert excinfo.value.status_code == 500
+    assert f"{base_url}/rhn/manager/api/system/listSystems" in str(excinfo.value)
 
 @pytest.mark.asyncio
 async def test_auth_failure_401(mock_uyuni):
@@ -865,6 +869,7 @@ async def test_auth_failure_401(mock_uyuni):
     with pytest.raises(AuthError) as excinfo:
         await server._list_systems("mock_token")
     assert excinfo.value.status_code == 401
+    assert f"{base_url}/rhn/manager/api/oidcLogin" in str(excinfo.value)
 
 @pytest.mark.asyncio
 async def test_add_system_already_exists(mock_uyuni, mock_ctx, monkeypatch):
@@ -949,6 +954,7 @@ async def test_resolve_system_id_by_name_multiple_found(mock_uyuni, mock_ctx):
     with pytest.raises(UnexpectedResponse) as excinfo:
         await server._get_system_details(name, mock_ctx, "mock_token")
     assert "Multiple systems found" in str(excinfo.value)
+    assert f"{base_url}/rhn/manager/api/system/getId" in str(excinfo.value)
 
 @pytest.mark.asyncio
 async def test_malformed_api_response(mock_uyuni):

--- a/uyuni-connection-config-stdio.example.env
+++ b/uyuni-connection-config-stdio.example.env
@@ -1,5 +1,5 @@
 # Required: Basic server parameters.
-UYUNI_SERVER=example_server:example_port
+UYUNI_SERVER=https://example_server:example_port
 UYUNI_USER=example_user
 UYUNI_PASS=example_password
 


### PR DESCRIPTION
This PR hardens the auth-related configuration contract and adds some minor QoL improvements:

- Accept optional URI scheme (backwards compatible)
- Enforce accepted URI schemes
- Normalize configured URIs
- Warn if auth is not enabled
- Improve config related logging
- Adds unit tests for config handling