### PR TITLE
docker-compose deployment hardening

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,6 +19,7 @@ cp deploy/stack.env.example deploy/stack.env
 ```
 
 2. Edit `deploy/stack.env` and set:
+- `UYUNI_PUBLIC_HOSTNAME`
 - `UYUNI_MCP_PUBLIC_URL`
 - `KEYCLOAK_BOOTSTRAP_ADMIN_PASSWORD`
 
@@ -256,7 +257,7 @@ Use it when your client sends non-Keycloak DCR metadata and Keycloak rejects it.
 - Issuer mismatch errors:
   Re-check all issuer values in the alignment section.
 - MCP cannot reach Uyuni:
-  Confirm `UYUNI_SERVER=uyuni-server` and shared `uyuni` network.
+  Confirm that Uyuni is reachable at `uyuni-server` inside shared `uyuni` network.
 - Watch service logs during auth and tool calls:
 
 ```bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,6 +31,8 @@ docker compose --env-file deploy/stack.env up -d --build
 docker compose --env-file deploy/stack.env ps
 ```
 
+This builds a small Keycloak image that includes the realm import files from `deploy/keycloak/import`.
+
 4. Verify endpoints:
 
 ```bash
@@ -128,6 +130,8 @@ ssh -fnNT -L /tmp/remote-podman.sock:/run/podman/podman.sock <user>@<remote-host
 export DOCKER_HOST="unix:///tmp/remote-podman.sock"
 docker info
 ```
+
+The Keycloak realm import files are copied into the Keycloak image during `docker compose build`, so they are sent to the remote daemon with the build context. This avoids bind-mounting `./deploy/keycloak/import`, which would otherwise have to exist on the remote host filesystem.
 
 Cleanup when finished with deployment:
 

--- a/deploy/keycloak/Dockerfile
+++ b/deploy/keycloak/Dockerfile
@@ -1,0 +1,4 @@
+ARG KEYCLOAK_IMAGE_TAG=26.1.4
+FROM quay.io/keycloak/keycloak:${KEYCLOAK_IMAGE_TAG}
+
+COPY import/ /opt/keycloak/data/import/

--- a/deploy/stack.env.example
+++ b/deploy/stack.env.example
@@ -2,8 +2,9 @@
 
 # Required for this deployment
 
-# Uyuni API hostname on the shared Podman network.
-UYUNI_SERVER=uyuni-server
+# Public Uyuni hostname (without the scheme) to advertise while still routing internally via compose.
+# Useful when you want Uyuni URLs emitted by the MCP server to be publicly reachable.
+UYUNI_PUBLIC_HOSTNAME=cb-suma.suse.lab
 # Public MCP base URL used by clients (without trailing /mcp).
 # The MCP discovery endpoint advertises this value as the protected resource URL.
 UYUNI_MCP_PUBLIC_URL=http://<container_hostname_or_ip>:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,11 @@ services:
       - uyuni
 
   keycloak:
-    image: quay.io/keycloak/keycloak:${KEYCLOAK_IMAGE_TAG:-26.1.4}
+    build:
+      context: ./deploy/keycloak
+      args:
+        KEYCLOAK_IMAGE_TAG: ${KEYCLOAK_IMAGE_TAG:-26.1.4}
+    image: mcp-server-uyuni-keycloak:local
     restart: unless-stopped
     ports:
       - "${KEYCLOAK_BIND_PORT:-8080}:8080"
@@ -61,7 +65,6 @@ services:
       KC_HOSTNAME_PORT: ${KEYCLOAK_PUBLIC_PORT:-8080}
     volumes:
       - keycloak-data:/opt/keycloak/data/h2
-      - ./deploy/keycloak/import:/opt/keycloak/data/import:ro,z
     networks:
       - uyuni
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     image: mcp-server-uyuni:local
     restart: unless-stopped
     depends_on:
+      - uyuni-server-public
       - keycloak
     ports:
       - "${MCP_BIND_PORT:-8000}:8000"
     environment:
-      UYUNI_SERVER: ${UYUNI_SERVER:-uyuni-server}
+      UYUNI_SERVER: ${UYUNI_PUBLIC_HOSTNAME:-uyuni-server}
       UYUNI_MCP_TRANSPORT: http
       UYUNI_MCP_HOST: 0.0.0.0
       UYUNI_MCP_PORT: ${MCP_BIND_PORT:-8000}
@@ -24,6 +25,17 @@ services:
       UYUNI_SSH_PRIV_KEY_PASS: ${UYUNI_SSH_PRIV_KEY_PASS:-}
     networks:
       - uyuni
+
+  uyuni-server-public:
+    image: docker.io/alpine/socat:1.8.0.3
+    restart: unless-stopped
+    command:
+      - "TCP-LISTEN:443,fork,reuseaddr"
+      - "TCP:uyuni-server:443"
+    networks:
+      uyuni:
+        aliases:
+          - ${UYUNI_PUBLIC_HOSTNAME:-uyuni-server}
 
   keycloak-dcr-proxy:
     profiles:


### PR DESCRIPTION
This PR adds the following enhancements to the compose deployment:

1. Pack import data into Keycloak image, so no bind mount is required when deploying remotely
2. Add public hostname routing with `socat`, so the URLs emitted from the MCP server (action URLs, etc.) are publicly reachable (`https://server.example.com/rhn/...` instead of `https://uyuni-server/rhn/...`)