### PR TITLE
fix dockerfile.test

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,12 +1,12 @@
 # Use openSUSE Leap as the base to match the production Dockerfile.
-FROM opensuse/leap:latest
+FROM opensuse/tumbleweed:latest
 
 # Install Python 3.13, pip, uv, and build dependencies.
 RUN zypper -n --gpg-auto-import-keys ref && \
-    zypper -n in python313-pip python313-devel gcc && \
+    zypper -n in python313-pip python313-pipx python313-devel gcc && \
     zypper -n clean --all
 
-RUN python3.13 -m pip install uv
+RUN pipx install uv
 
 WORKDIR /app
 
@@ -16,6 +16,7 @@ COPY pyproject.toml uv.lock ./
 
 # Create a virtual environment and install all dependencies, including dev dependencies for testing.
 RUN --mount=type=cache,target=/root/.cache/uv \
+    export PATH=$PATH:/root/.local/bin/ && \
     uv venv --python /usr/bin/python3.13 && \
     . .venv/bin/activate && \
     uv sync --frozen --dev --no-install-project

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,8 @@
 # Use openSUSE Leap as the base to match the production Dockerfile.
 FROM opensuse/tumbleweed:latest
 
+ENV PATH "$PATH:/root/.local/bin"
+
 # Install Python 3.13, pip, uv, and build dependencies.
 RUN zypper -n --gpg-auto-import-keys ref && \
     zypper -n in python313-pip python313-pipx python313-devel gcc && \


### PR DESCRIPTION
There seems to be an issue with the dockerfile.test: we can't use 15.6 because it is too old, but 16.0 requires a v2 CPU instruction set, which is not available in the jenkins worker (it is a vm with an emulated qemu cpu). 

Tumbleweed does not have this requirements, but then the installation of the helper tool uv differs from leap